### PR TITLE
Add an example rule for non-zere exit code of the essential container

### DIFF
--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -29,14 +29,27 @@ module "ecs_to_slack" {
     eventName  = [{ "anything-but" = "SERVICE_TASK_START_IMPAIRED" }] # and only with this eventName
   }
 
-  # Add a fully custom rule, for all started tasks of a certain service
   custom_event_rules = {
+    # Custom rule for all started tasks of a certain service
     ECSTaskStateChange_Started = {
       detail-type = ["ECS Task State Change"]
       detail = {
         clusterArn = [data.aws_ecs_cluster.this.arn],
         lastStatus = ["STARTED"]
         group      = ["service:EXAMPLE-SERVICE-NAME"]
+      }
+    }
+
+    # Custom rule for all stopped tasks with container's non-zero exit code
+    ECSTaskStateChange_StoppedNonZero = {
+      detail-type = ["ECS Task State Change"]
+      detail = {
+        clusterArn = [data.aws_ecs_cluster.this.arn],
+        lastStatus = ["STOPPED"]
+        stopCode   = "EssentialContainerExited"
+        containers = {
+          exitCode = [{ "anything-but" = 0 }]
+        }
       }
     }
   }

--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -30,7 +30,7 @@ module "ecs_to_slack" {
   }
 
   custom_event_rules = {
-    # Custom rule for all started tasks of a certain service
+    # Custom rule which triggers on all started tasks of a certain service
     ECSTaskStateChange_Started = {
       detail-type = ["ECS Task State Change"]
       detail = {
@@ -40,7 +40,7 @@ module "ecs_to_slack" {
       }
     }
 
-    # Custom rule for all stopped tasks with container's non-zero exit code
+    # Custom rule which triggers on all stopped tasks with non-zero exit code of the essential container
     ECSTaskStateChange_StoppedNonZero = {
       detail-type = ["ECS Task State Change"]
       detail = {


### PR DESCRIPTION
That rule will ignore the event if the essential container exited with code 0 (assuming that it is a normal and expected behavior).

Closes #8 