### PR TITLE
Fix the type of "custom_event_rules" variable, update linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.52.0
+  rev: v1.74.1
   hooks:
     - id: terraform_fmt
     - id: terraform_tflint
     - id: terraform_validate
     - id: terraform_docs
     - id: terraform_tfsec
-    - id: checkov
+      args:
+        - --args=--config-file=__GIT_WORKING_DIR__/.tfsec.yaml
+    - id: terraform_checkov

--- a/.tfsec.yaml
+++ b/.tfsec.yaml
@@ -1,0 +1,3 @@
+---
+exclude:
+  - aws-lambda-enable-tracing

--- a/README.md
+++ b/README.md
@@ -30,15 +30,12 @@ You can find more examples in the [`examples/`](./examples/) directory
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 
@@ -57,7 +54,7 @@ You can find more examples in the [`examples/`](./examples/) directory
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_custom_event_rules"></a> [custom\_event\_rules](#input\_custom\_event\_rules) | A map of objects representing the custom EventBridge rule which will be created in addition to the default rules. | <pre>map(object({<br>    detail-type = any<br>    detail      = any<br>  }))</pre> | `{}` | no |
+| <a name="input_custom_event_rules"></a> [custom\_event\_rules](#input\_custom\_event\_rules) | A map of objects representing the custom EventBridge rule which will be created in addition to the default rules. | `any` | `{}` | no |
 | <a name="input_ecs_deployment_state_event_rule_detail"></a> [ecs\_deployment\_state\_event\_rule\_detail](#input\_ecs\_deployment\_state\_event\_rule\_detail) | The content of the `detail` section in the EvenBridge Rule for `ECS Deployment State Change` events. Use it to filter the events which will be processed and sent to Slack. | `any` | <pre>{<br>  "eventType": [<br>    "ERROR"<br>  ]<br>}</pre> | no |
 | <a name="input_ecs_service_action_event_rule_detail"></a> [ecs\_service\_action\_event\_rule\_detail](#input\_ecs\_service\_action\_event\_rule\_detail) | The content of the `detail` section in the EvenBridge Rule for `ECS Service Action` events. Use it to filter the events which will be processed and sent to Slack. | `any` | <pre>{<br>  "eventType": [<br>    "WARN",<br>    "ERROR"<br>  ]<br>}</pre> | no |
 | <a name="input_ecs_task_state_event_rule_detail"></a> [ecs\_task\_state\_event\_rule\_detail](#input\_ecs\_task\_state\_event\_rule\_detail) | The content of the `detail` section in the EvenBridge Rule for `ECS Task State Change` events. Use it to filter the events which will be processed and sent to Slack. | `any` | <pre>{<br>  "lastStatus": [<br>    "STOPPED"<br>  ],<br>  "stoppedReason": [<br>    {<br>      "anything-but": {<br>        "prefix": "Scaling activity initiated by (deployment ecs-svc/"<br>      }<br>    }<br>  ]<br>}</pre> | no |

--- a/variables.tf
+++ b/variables.tf
@@ -69,11 +69,13 @@ variable "ecs_service_action_event_rule_detail" {
 
 variable "custom_event_rules" {
   description = "A map of objects representing the custom EventBridge rule which will be created in addition to the default rules."
-  type = map(object({
-    detail-type = any
-    detail      = any
-  }))
-  default = {}
+  type        = any
+  default     = {}
+
+  validation {
+    error_message = "Each rule object should have both 'detail' and 'detail-type' keys."
+    condition     = alltrue([for name, rule in var.custom_event_rules : length(setintersection(keys(rule), ["detail", "detail-type"])) == 2])
+  }
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -6,17 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.69"
     }
-    external = {
-      source  = "hashicorp/external"
-      version = ">= 1.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
1) [Fix the type of `custom_event_rules`](https://github.com/fivexl/terraform-aws-ecs-events-to-slack/commit/4f67dfa889cee6b1994c11c0c91e0a2f38588a80) 

Switched it to "any" to allow using different structs in the rules and avoid terraform throwing an error
while trying to do a duct typing of all elements.
In order to keep the variable type static, we added a validation block. It checks that "detail" and "detail-type" is always set.

If fixes that error in `examples/complex`:
```
$ terraform validate .
╷
│ Error: Invalid value for input variable
│
│   on main.tf line 32, in module "ecs_to_slack":
│   32:   custom_event_rules = {
│   33:     # Custom rule which triggers on all started tasks of a certain service
│   34:     ECSTaskStateChange_Started = {
│   35:       detail-type = ["ECS Task State Change"]
│   36:       detail = {
│   37:         clusterArn = [data.aws_ecs_cluster.this.arn],
│   38:         lastStatus = ["STARTED"]
│   39:         group      = ["service:EXAMPLE-SERVICE-NAME"]
│   40:       }
│   41:     }
│   42:     # Custom rule which triggers on all stopped tasks with non-zero exit code of the essential container
│   43:     ECSTaskStateChange_StoppedNonZero = {
│   44:       detail-type = ["ECS Task State Change"]
│   45:       detail = {
│   46:         clusterArn = [data.aws_ecs_cluster.this.arn],
│   47:         lastStatus = ["STOPPED"]
│   48:         stopCode   = "EssentialContainerExited"
│   49:         containers = {
│   50:           exitCode = [{ "anything-but" = 0 }]
│   51:         }
│   52:       }
│   53:     }
│   54:   }
│
│ The given value is not suitable for module.ecs_to_slack.var.custom_event_rules
│ declared at ../../variables.tf:70,1-30: cannot find a common base type for all
│ elements.
```

2. [Remove provider requirements of included modules](https://github.com/fivexl/terraform-aws-ecs-events-to-slack/commit/4ac654dd21d1bd10a3c375041a893336e3f76a47) 

terraform automatically inherits requirement of the dependent modules, no need to add it here explicitly

3. [Update pre-commit-terraform config and make it passing](https://github.com/fivexl/terraform-aws-ecs-events-to-slack/commit/ae2628097de61c8ec0e2907e3418e72357cac39f)